### PR TITLE
Update api-wasm.md

### DIFF
--- a/docs/api-wasm.md
+++ b/docs/api-wasm.md
@@ -158,11 +158,10 @@ use incubed as Web3Provider in web3js
 ```js
 /// use incubed as Web3Provider in web3js 
 
-// import in3-Module
-import { IN3 } from 'in3-wasm'
+const in3wasm = require('in3-wasm');
 const Web3 = require('web3')
 
-const in3 = new IN3({
+const in3 = new in3wasm.IN3({
     proof: 'standard',
     signatureCount: 1,
     requestCount: 1,
@@ -179,8 +178,7 @@ const web3 = new Web3(in3.createWeb3Provider());
     const block = await web3.eth.getBlock('latest')
     console.log("Block : ", block)
 
-})().catch(console.error);
-```
+})().catch(console.error);```
 
 ### in3_in_browser
 


### PR DESCRIPTION
Trying to run the example generated in an error: 

```js
SyntaxError: The requested module 'in3-wasm' is expected to be of type CommonJS,
which does not support named exports. CommonJS modules can be imported by importing the default export.
For example: import pkg from 'in3-wasm'; const { IN3 } = pkg;
```
Thus, added this change, this is executing as expected.

[Reference](https://github.com/slockit/in3/issues)